### PR TITLE
Problem that occurs when batch size is 1

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -420,7 +420,7 @@ class FinalLayer(nn.Module):
         ffs = []
         preds = []
         for i in range(len(x)):
-            emb = self.avg_pool(x[i]).squeeze()
+            emb = self.avg_pool(x[i]).squeeze(dim=-1).squeeze(dim=-1)
             if self.withLAI:
                 if self.n_cams > 0 and self.n_views >0:
                     emb = emb + self.LAI[i, cam * self.n_views + view, :]


### PR DESCRIPTION
# Description
When the batch size is 1, when the squeeze() operation is performed, emb is changed to a 1-dimensional array rather than a 2-dimensional array.

A problem occurs in the Slice operation below. models.py line 432.
``` python
...
422        for i in range(len(x)):
423            emb = self.avg_pool(x[i]).squeeze()
424            if self.withLAI:
425                if self.n_cams > 0 and self.n_views >0:
426                    emb = emb + self.LAI[i, cam * self.n_views + view, :]
427                elif self.n_cams >0:
428                    emb = emb + self.LAI[i, cam, :]
429                else:
430                    emb = emb + self.LAI[i, view, :]
431            for j in range(self.n_groups):
432                aux_emb = emb[:,int(2048/self.n_groups*j):int(2048/self.n_groups*(j+1))]
...
```
 so the code is changed to remove only the two 1s at the end of the dimension.

# TODO
- [x] Fix models.py
- [x] Review code
- [x] merge with main branch